### PR TITLE
Refactor redirect statements in controllers

### DIFF
--- a/PrimeVillasWeb/Controllers/AmenityController.cs
+++ b/PrimeVillasWeb/Controllers/AmenityController.cs
@@ -46,7 +46,7 @@ namespace PrimeVillasWeb.Controllers
                 _unitOfWork.Save();
                 TempData["success"] = "Amenity  added successfully";
 
-                return RedirectToAction("index");
+                return RedirectToAction(nameof(Index));
             }
 
             amenityVMObj.VillaList = _unitOfWork.Villa.GetAll().Select(u => new SelectListItem
@@ -90,7 +90,7 @@ namespace PrimeVillasWeb.Controllers
                 _unitOfWork.Save();
                 TempData["success"] = "Amenity Updated successfully";
 
-                return RedirectToAction("index");
+                return RedirectToAction(nameof(Index));
             }
 
             amenityVM.VillaList = _unitOfWork.Villa.GetAll().Select(u => new SelectListItem
@@ -134,7 +134,7 @@ namespace PrimeVillasWeb.Controllers
             _unitOfWork.Amenity.Remove(obj);
             _unitOfWork.Save();
             TempData["success"] = "Amenity removed successfully.";
-            return RedirectToAction("index");
+            return RedirectToAction(nameof(Index));
         }
     }
 }

--- a/PrimeVillasWeb/Controllers/VillaController.cs
+++ b/PrimeVillasWeb/Controllers/VillaController.cs
@@ -98,7 +98,7 @@ namespace PrimeVillasWeb.Controllers
                 _unitOfWork.Villa.Update(villaObj);
                 _unitOfWork.Save();
                 TempData["success"] = "Villa updated successfully";
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
 
             }
             return View();
@@ -134,7 +134,7 @@ namespace PrimeVillasWeb.Controllers
                 _unitOfWork.Villa.Remove(obj);
                 _unitOfWork.Save();
                 TempData["success"] = "Villa deleted successfully";
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
 
             return View();

--- a/PrimeVillasWeb/Controllers/VillaNumberController.cs
+++ b/PrimeVillasWeb/Controllers/VillaNumberController.cs
@@ -53,7 +53,7 @@ namespace PrimeVillasWeb.Controllers
                 _unitOfWork.Save();
                 TempData["success"] = "Villa Number added successfully";
 
-                return RedirectToAction("index");
+                return RedirectToAction(nameof(Index));
             }
 
             if (roomNumberExists)
@@ -102,7 +102,7 @@ namespace PrimeVillasWeb.Controllers
                 _unitOfWork.Save();
                 TempData["success"] = "Villa Number Updated successfully";
 
-                return RedirectToAction("index");
+                return RedirectToAction(nameof(Index));
             }
 
             villaNumberVM.VillaList = _unitOfWork.Villa.GetAll().Select(u => new SelectListItem
@@ -147,7 +147,7 @@ namespace PrimeVillasWeb.Controllers
             _unitOfWork.VillaNumber.Remove(obj);
             _unitOfWork.Save();
             TempData["success"] = "Villa Number removed successfully.";
-            return RedirectToAction("index");
+            return RedirectToAction(nameof(Index));
         }
     }
 }


### PR DESCRIPTION
Updated return statements in `AmenityController`, `VillaController`, and `VillaNumberController` to use `nameof(Index)` instead of string literals. This improves code maintainability and reduces the risk of errors during refactoring.